### PR TITLE
Fix TypeError in ContextCache::clear() for non-Entry owners

### DIFF
--- a/src/base/ContextCache.php
+++ b/src/base/ContextCache.php
@@ -3,6 +3,7 @@
 namespace madebyraygun\blockloader\base;
 
 use Craft;
+use craft\base\Element;
 use craft\elements\Asset;
 use craft\elements\Entry;
 use craft\events\ModelEvent;
@@ -14,9 +15,9 @@ class ContextCache
 {
     private static $CACHE = null;
 
-    private static function getKey(Entry $entry): string
+    private static function getKey(Element $element): string
     {
-        return strval($entry->id) . '-' . strval($entry->siteId);
+        return strval($element->id) . '-' . strval($element->siteId);
     }
 
     public static function set(Entry $entry, Collection $descriptors): void
@@ -42,9 +43,9 @@ class ContextCache
         return static::$CACHE;
     }
 
-    public static function clear(Entry $entry): void
+    public static function clear(Element $element): void
     {
-        $key = static::getKey($entry);
+        $key = static::getKey($element);
         Plugin::$plugin->cache->delete($key);
     }
 


### PR DESCRIPTION
## Summary
- Widens type hint on `ContextCache::clear()` and `getKey()` from `Entry` to `Element`
- Fixes TypeError when `clearRelations()` passes a non-Entry owner (e.g. `GlobalSet`) to `clear()`

Fixes #22

## Root Cause
`clearRelations()` iterates related entries and calls `clear($entry->owner)` on line 73. The `owner` property can be any `Element` type, but `clear()` and `getKey()` only accepted `Entry`. Both methods only use `id` and `siteId`, which are available on all `Element` instances.

## Test plan
- [ ] Save a draft of an entry whose nested entries are owned by a GlobalSet
- [ ] Confirm no TypeError is thrown
- [ ] Confirm cache is properly cleared for both entries and non-entry owners