### PR TITLE
Fix: handle non-serializable objects in cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 3.1.6 - 2026-02-17
+
+### Fixed
+
+- Handle non-serializable objects in block context cache gracefully instead of throwing an exception ([#11](https://github.com/madebyraygun/craft-block-loader/issues/11))
+
 ## 3.1.4 - 2025-07-22
 
 ### Fixed

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
   "name": "madebyraygun/craft-block-loader",
   "description": "Context loader for Craft CMS matrix blocks and nested entries.",
-  "version": "3.1.4",
+  "version": "3.1.6",
   "type": "craft-plugin",
   "require": {
     "php": ">=8.2.0",

--- a/src/base/ContextCache.php
+++ b/src/base/ContextCache.php
@@ -26,7 +26,13 @@ class ContextCache
             return;
         }
         $key = static::getKey($entry);
-        Plugin::$plugin->cache->set($key, serialize($descriptors->toArray()));
+        try {
+            $serialized = serialize($descriptors->toArray());
+        } catch (\Exception $e) {
+            Craft::warning("Block loader cache skipped for entry {$entry->id}: {$e->getMessage()}", __METHOD__);
+            return;
+        }
+        Plugin::$plugin->cache->set($key, $serialized);
     }
 
     public static function get(Entry $entry): ?Collection


### PR DESCRIPTION
## Summary

- Wraps `serialize()` in `ContextCache::set()` with a try-catch so non-serializable objects (`Closure`, `finfo`, etc.) in block contexts gracefully skip caching instead of throwing a fatal exception
- Bumps version to 3.1.6

Fixes #11