### PR TITLE
fix: defer cache invalidation to end of request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 3.1.7 - 2026-04-16
+
+### Fixed
+
+- Defer cache invalidation to end of request to prevent timeouts on entries with many nested elements ([#25](https://github.com/madebyraygun/craft-block-loader/issues/25))
+- Add `site('*')` to relation queries for correct multi-site cache invalidation
+- Console and queue contexts fall back to immediate invalidation since `EVENT_AFTER_REQUEST` doesn't fire
+
 ## 3.1.6 - 2026-02-17
 
 ### Fixed

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
   "name": "madebyraygun/craft-block-loader",
   "description": "Context loader for Craft CMS matrix blocks and nested entries.",
-  "version": "3.1.6",
+  "version": "3.1.7",
   "type": "craft-plugin",
   "require": {
     "php": ">=8.2.0",

--- a/src/base/ContextCache.php
+++ b/src/base/ContextCache.php
@@ -73,6 +73,7 @@ class ContextCache
     {
         $entries = Entry::find()
             ->relatedTo($element)
+            ->site('*')
             ->all();
 
         $cleanedIds = [];
@@ -106,7 +107,7 @@ class ContextCache
     }
 
     /**
-     * Queue an element for deferred cache clear + relation invalidation.
+     * Queue an element for deferred direct cache clear.
      */
     private static function queueClear(Element $element): void
     {
@@ -128,52 +129,71 @@ class ContextCache
      */
     private static function processDeferredInvalidation(): void
     {
-        // 1. Clear directly queued elements
-        foreach (static::$pendingClears as $element) {
-            static::clear($element);
-        }
+        try {
+            // 1. Clear directly queued elements
+            foreach (static::$pendingClears as $element) {
+                static::clear($element);
+            }
 
-        // 2. Batch-clear relations for all queued elements
-        if (!empty(static::$pendingRelationElements)) {
-            $elements = array_values(static::$pendingRelationElements);
-            $entries = Entry::find()
-                ->relatedTo($elements)
-                ->all();
+            // 2. Clear cache for all entries related to queued elements
+            if (!empty(static::$pendingRelationElements)) {
+                $elements = array_values(static::$pendingRelationElements);
+                $chunks = array_chunk($elements, 100);
+                foreach ($chunks as $chunk) {
+                    $entries = Entry::find()
+                        ->relatedTo($chunk)
+                        ->site('*')
+                        ->all();
 
-            $cleanedIds = [];
-            foreach ($entries as $entry) {
-                if (in_array($entry->id, $cleanedIds)) {
-                    continue;
-                }
-                $cleanedIds[] = $entry->id;
-                static::clear($entry);
-                if ($entry->owner && !in_array($entry->ownerId, $cleanedIds)) {
-                    $cleanedIds[] = $entry->ownerId;
-                    static::clear($entry->owner);
+                    $cleanedIds = [];
+                    foreach ($entries as $entry) {
+                        if (in_array($entry->id, $cleanedIds)) {
+                            continue;
+                        }
+                        $cleanedIds[] = $entry->id;
+                        static::clear($entry);
+                        if ($entry->owner && !in_array($entry->ownerId, $cleanedIds)) {
+                            $cleanedIds[] = $entry->ownerId;
+                            static::clear($entry->owner);
+                        }
+                    }
                 }
             }
+        } catch (\Throwable $e) {
+            Craft::error(
+                'Block loader deferred cache invalidation failed: ' . $e->getMessage(),
+                __METHOD__
+            );
+        } finally {
+            static::$pendingClears = [];
+            static::$pendingRelationElements = [];
         }
-
-        // Reset state
-        static::$pendingClears = [];
-        static::$pendingRelationElements = [];
     }
 
     public static function attachEventHandlers(): void
     {
+        // Console/queue: use immediate invalidation (EVENT_AFTER_REQUEST doesn't fire)
+        if (Craft::$app->request->isConsoleRequest) {
+            Event::on(Asset::class, Asset::EVENT_AFTER_SAVE, function(ModelEvent $event) {
+                static::clearRelations($event->sender);
+            });
+            Event::on(Entry::class, Entry::EVENT_AFTER_SAVE, function(ModelEvent $event) {
+                static::clear($event->sender);
+                static::clearRelations($event->sender);
+            });
+            return;
+        }
+
+        // Web requests: defer invalidation to end of request
         static::ensureDeferredHandler();
 
-        // Handle Asset saves — defer relation clearing
         Event::on(Asset::class, Asset::EVENT_AFTER_SAVE, function(ModelEvent $event) {
-            $asset = $event->sender;
-            static::queueRelationClear($asset);
+            static::queueRelationClear($event->sender);
         });
 
-        // Handle Entry saves — defer both direct clear and relation clearing
         Event::on(Entry::class, Entry::EVENT_AFTER_SAVE, function(ModelEvent $event) {
-            $entry = $event->sender;
-            static::queueClear($entry);
-            static::queueRelationClear($entry);
+            static::queueClear($event->sender);
+            static::queueRelationClear($event->sender);
         });
     }
 }

--- a/src/base/ContextCache.php
+++ b/src/base/ContextCache.php
@@ -9,11 +9,20 @@ use craft\elements\Entry;
 use craft\events\ModelEvent;
 use Illuminate\Support\Collection;
 use madebyraygun\blockloader\Plugin;
+use yii\base\Application;
 use yii\base\Event;
 
 class ContextCache
 {
     private static $CACHE = null;
+
+    /**
+     * Elements queued for deferred cache invalidation.
+     * Processed once at end of request instead of per-element.
+     */
+    private static array $pendingClears = [];
+    private static array $pendingRelationElements = [];
+    private static bool $deferredHandlerRegistered = false;
 
     private static function getKey(Element $element): string
     {
@@ -81,19 +90,90 @@ class ContextCache
         }
     }
 
+    /**
+     * Register the end-of-request handler that processes all deferred invalidations.
+     */
+    private static function ensureDeferredHandler(): void
+    {
+        if (static::$deferredHandlerRegistered) {
+            return;
+        }
+        static::$deferredHandlerRegistered = true;
+
+        Event::on(Application::class, Application::EVENT_AFTER_REQUEST, function() {
+            static::processDeferredInvalidation();
+        });
+    }
+
+    /**
+     * Queue an element for deferred cache clear + relation invalidation.
+     */
+    private static function queueClear(Element $element): void
+    {
+        $key = static::getKey($element);
+        static::$pendingClears[$key] = $element;
+    }
+
+    /**
+     * Queue an element whose relations need deferred invalidation.
+     */
+    private static function queueRelationClear(Element $element): void
+    {
+        $key = $element->id . '-' . ($element instanceof Entry ? 'entry' : 'asset');
+        static::$pendingRelationElements[$key] = $element;
+    }
+
+    /**
+     * Process all deferred cache invalidations in a single pass.
+     */
+    private static function processDeferredInvalidation(): void
+    {
+        // 1. Clear directly queued elements
+        foreach (static::$pendingClears as $element) {
+            static::clear($element);
+        }
+
+        // 2. Batch-clear relations for all queued elements
+        if (!empty(static::$pendingRelationElements)) {
+            $elements = array_values(static::$pendingRelationElements);
+            $entries = Entry::find()
+                ->relatedTo($elements)
+                ->all();
+
+            $cleanedIds = [];
+            foreach ($entries as $entry) {
+                if (in_array($entry->id, $cleanedIds)) {
+                    continue;
+                }
+                $cleanedIds[] = $entry->id;
+                static::clear($entry);
+                if ($entry->owner && !in_array($entry->ownerId, $cleanedIds)) {
+                    $cleanedIds[] = $entry->ownerId;
+                    static::clear($entry->owner);
+                }
+            }
+        }
+
+        // Reset state
+        static::$pendingClears = [];
+        static::$pendingRelationElements = [];
+    }
+
     public static function attachEventHandlers(): void
     {
-        // Handle Asset saves
+        static::ensureDeferredHandler();
+
+        // Handle Asset saves — defer relation clearing
         Event::on(Asset::class, Asset::EVENT_AFTER_SAVE, function(ModelEvent $event) {
             $asset = $event->sender;
-            static::clearRelations($asset);
+            static::queueRelationClear($asset);
         });
 
-        // Handle Entry saves
+        // Handle Entry saves — defer both direct clear and relation clearing
         Event::on(Entry::class, Entry::EVENT_AFTER_SAVE, function(ModelEvent $event) {
             $entry = $event->sender;
-            static::clear($entry);
-            static::clearRelations($entry);
+            static::queueClear($entry);
+            static::queueRelationClear($entry);
         });
     }
 }


### PR DESCRIPTION
## Summary

- Fixes #25 — `ContextCache::clearRelations()` firing per nested element during draft apply caused 60s+ timeout on entries with many blocks
- Event handlers now queue elements into deduped arrays instead of immediately running expensive `relatedTo()` queries
- A single `EVENT_AFTER_REQUEST` handler processes all queued invalidations in one batched query

## What changed

`attachEventHandlers()` no longer calls `clear()` or `clearRelations()` directly. Instead:
1. `queueClear()` collects elements for direct cache deletion (keyed by `{id}-{siteId}`)
2. `queueRelationClear()` collects elements whose relations need invalidation (keyed by `{id}-{type}`)
3. `processDeferredInvalidation()` runs once at end of request — clears direct entries, then runs a single `Entry::find()->relatedTo($allElements)` for the batched relation lookup

The existing `clearRelations()` method is preserved for direct use (e.g., console commands, manual cache clearing).

## Test plan

- [ ] Apply a draft on an entry with many nested blocks (e.g., a course) — should complete without timeout
- [ ] Edit and save an entry with related assets — verify block cache is cleared on next page load
- [ ] Run `craft block-loader/expire-cache` — verify manual cache clearing still works