### PR TITLE
fix: skip cache invalidation for unpublished entries (#27)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 /.vscode
+.phpunit.cache/
+composer.lock

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 3.1.8 - 2026-05-21
+
+### Fixed
+
+- Skip cache invalidation entirely for saves that can't affect the live cache: drafts, revisions, propagating saves, bulk resaves, asset indexer passes, and non-live entries with no live-ness transition ([#27](https://github.com/madebyraygun/craft-block-loader/issues/27)). Eliminates the expensive `relatedTo()` fan-out on the common-case "no-op" save path (autosave on a draft, console resave, multi-site propagation).
+
 ## 3.1.7 - 2026-04-16
 
 ### Fixed

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
   "name": "madebyraygun/craft-block-loader",
   "description": "Context loader for Craft CMS matrix blocks and nested entries.",
-  "version": "3.1.7",
+  "version": "3.1.8",
   "type": "craft-plugin",
   "require": {
     "php": ">=8.2.0",

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,8 @@
   },
   "require-dev": {
     "craftcms/ecs": "dev-main",
-    "craftcms/phpstan": "dev-main"
+    "craftcms/phpstan": "dev-main",
+    "phpunit/phpunit": "^11.0"
   },
   "autoload": {
     "psr-4": {
@@ -39,7 +40,8 @@
   "scripts": {
     "check-cs": "ecs check --ansi",
     "fix-cs": "ecs check --ansi --fix",
-    "phpstan": "phpstan --memory-limit=1G"
+    "phpstan": "phpstan --memory-limit=1G",
+    "test": "phpunit"
   },
   "config": {
     "sort-packages": true,

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
+         bootstrap="vendor/autoload.php"
+         colors="true"
+         cacheDirectory=".phpunit.cache"
+         displayDetailsOnTestsThatTriggerWarnings="true">
+    <testsuites>
+        <testsuite name="Unit">
+            <directory>tests/Unit</directory>
+        </testsuite>
+    </testsuites>
+    <source>
+        <include>
+            <directory>src</directory>
+        </include>
+    </source>
+</phpunit>

--- a/src/base/ContextCache.php
+++ b/src/base/ContextCache.php
@@ -209,9 +209,15 @@ class ContextCache
         // Console/queue: use immediate invalidation (EVENT_AFTER_REQUEST doesn't fire)
         if (Craft::$app->request->isConsoleRequest) {
             Event::on(Asset::class, Asset::EVENT_AFTER_SAVE, function(ModelEvent $event) {
+                if (static::shouldSkipInvalidation($event->sender)) {
+                    return;
+                }
                 static::clearRelations($event->sender);
             });
             Event::on(Entry::class, Entry::EVENT_AFTER_SAVE, function(ModelEvent $event) {
+                if (static::shouldSkipInvalidation($event->sender)) {
+                    return;
+                }
                 static::clear($event->sender);
                 static::clearRelations($event->sender);
             });
@@ -222,10 +228,16 @@ class ContextCache
         static::ensureDeferredHandler();
 
         Event::on(Asset::class, Asset::EVENT_AFTER_SAVE, function(ModelEvent $event) {
+            if (static::shouldSkipInvalidation($event->sender)) {
+                return;
+            }
             static::queueRelationClear($event->sender);
         });
 
         Event::on(Entry::class, Entry::EVENT_AFTER_SAVE, function(ModelEvent $event) {
+            if (static::shouldSkipInvalidation($event->sender)) {
+                return;
+            }
             static::queueClear($event->sender);
             static::queueRelationClear($event->sender);
         });

--- a/src/base/ContextCache.php
+++ b/src/base/ContextCache.php
@@ -7,6 +7,7 @@ use craft\base\Element;
 use craft\elements\Asset;
 use craft\elements\Entry;
 use craft\events\ModelEvent;
+use craft\helpers\ElementHelper;
 use Illuminate\Support\Collection;
 use madebyraygun\blockloader\Plugin;
 use yii\base\Application;
@@ -67,6 +68,21 @@ class ContextCache
     public static function filterCacheableDescriptors(Collection $descriptors): Collection
     {
         return $descriptors->filter(fn($descriptor) => $descriptor->cacheable);
+    }
+
+    /**
+     * Returns true when the save can't affect the live block-loader cache and
+     * invalidation should be skipped entirely.
+     *
+     * Pure function of element state. Called at the top of every
+     * EVENT_AFTER_SAVE listener; no side effects.
+     */
+    public static function shouldSkipInvalidation(Element $element): bool
+    {
+        if (ElementHelper::isDraftOrRevision($element)) {
+            return true;
+        }
+        return false;
     }
 
     public static function clearRelations(mixed $element): void

--- a/src/base/ContextCache.php
+++ b/src/base/ContextCache.php
@@ -85,6 +85,9 @@ class ContextCache
         if ($element->propagating) {
             return true;
         }
+        if ($element->resaving) {
+            return true;
+        }
         return false;
     }
 

--- a/src/base/ContextCache.php
+++ b/src/base/ContextCache.php
@@ -88,6 +88,9 @@ class ContextCache
         if ($element->resaving) {
             return true;
         }
+        if ($element instanceof Asset && $element->getScenario() === Asset::SCENARIO_INDEX) {
+            return true;
+        }
         return false;
     }
 

--- a/src/base/ContextCache.php
+++ b/src/base/ContextCache.php
@@ -91,6 +91,15 @@ class ContextCache
         if ($element instanceof Asset && $element->getScenario() === Asset::SCENARIO_INDEX) {
             return true;
         }
+        if ($element instanceof Entry && $element->getStatus() !== Entry::STATUS_LIVE) {
+            $dirty = $element->getDirtyAttributes();
+            foreach (['enabled', 'postDate', 'expiryDate'] as $attr) {
+                if (in_array($attr, $dirty, true)) {
+                    return false;
+                }
+            }
+            return true;
+        }
         return false;
     }
 

--- a/src/base/ContextCache.php
+++ b/src/base/ContextCache.php
@@ -74,8 +74,7 @@ class ContextCache
      * Returns true when the save can't affect the live block-loader cache and
      * invalidation should be skipped entirely.
      *
-     * Pure function of element state. Called at the top of every
-     * EVENT_AFTER_SAVE listener; no side effects.
+     * Read-only; safe to call from event handlers.
      */
     public static function shouldSkipInvalidation(Element $element): bool
     {
@@ -92,8 +91,11 @@ class ContextCache
             return true;
         }
         if ($element instanceof Entry && $element->getStatus() !== Entry::STATUS_LIVE) {
+            // These attributes drive Entry::getStatus(); if any is dirty, the
+            // save may be transitioning the entry into or out of STATUS_LIVE
+            // and we can't skip invalidation.
             $dirty = $element->getDirtyAttributes();
-            foreach (['enabled', 'postDate', 'expiryDate'] as $attr) {
+            foreach (['enabled', 'enabledForSite', 'postDate', 'expiryDate'] as $attr) {
                 if (in_array($attr, $dirty, true)) {
                     return false;
                 }

--- a/src/base/ContextCache.php
+++ b/src/base/ContextCache.php
@@ -82,6 +82,9 @@ class ContextCache
         if (ElementHelper::isDraftOrRevision($element)) {
             return true;
         }
+        if ($element->propagating) {
+            return true;
+        }
         return false;
     }
 

--- a/tests/Unit/ContextCacheTest.php
+++ b/tests/Unit/ContextCacheTest.php
@@ -49,4 +49,16 @@ final class ContextCacheTest extends TestCase
 
         self::assertTrue(ContextCache::shouldSkipInvalidation($entry));
     }
+
+    public function testSkipsAssetIndexerPass(): void
+    {
+        $asset = $this->createMock(Asset::class);
+        $asset->method('getIsDraft')->willReturn(false);
+        $asset->method('getIsRevision')->willReturn(false);
+        $asset->method('getScenario')->willReturn(Asset::SCENARIO_INDEX);
+        $asset->propagating = false;
+        $asset->resaving = false;
+
+        self::assertTrue(ContextCache::shouldSkipInvalidation($asset));
+    }
 }

--- a/tests/Unit/ContextCacheTest.php
+++ b/tests/Unit/ContextCacheTest.php
@@ -88,7 +88,20 @@ final class ContextCacheTest extends TestCase
         self::assertFalse(ContextCache::shouldSkipInvalidation($entry));
     }
 
-    public function testDoesNotSkipDisabledEntryWhenPostDateIsDirty(): void
+    public function testDoesNotSkipDisabledEntryWhenEnabledForSiteIsDirty(): void
+    {
+        $entry = $this->createMock(Entry::class);
+        $entry->method('getIsDraft')->willReturn(false);
+        $entry->method('getIsRevision')->willReturn(false);
+        $entry->method('getStatus')->willReturn(Entry::STATUS_DISABLED);
+        $entry->method('getDirtyAttributes')->willReturn(['enabledForSite']);
+        $entry->propagating = false;
+        $entry->resaving = false;
+
+        self::assertFalse(ContextCache::shouldSkipInvalidation($entry));
+    }
+
+    public function testDoesNotSkipPendingEntryWhenPostDateIsDirty(): void
     {
         $entry = $this->createMock(Entry::class);
         $entry->method('getIsDraft')->willReturn(false);
@@ -101,7 +114,7 @@ final class ContextCacheTest extends TestCase
         self::assertFalse(ContextCache::shouldSkipInvalidation($entry));
     }
 
-    public function testDoesNotSkipDisabledEntryWhenExpiryDateIsDirty(): void
+    public function testDoesNotSkipExpiredEntryWhenExpiryDateIsDirty(): void
     {
         $entry = $this->createMock(Entry::class);
         $entry->method('getIsDraft')->willReturn(false);
@@ -151,5 +164,50 @@ final class ContextCacheTest extends TestCase
         $entry->resaving = false;
 
         self::assertFalse(ContextCache::shouldSkipInvalidation($entry));
+    }
+
+    public function testDoesNotSkipAssetOnDefaultScenario(): void
+    {
+        $asset = $this->createMock(Asset::class);
+        $asset->method('getIsDraft')->willReturn(false);
+        $asset->method('getIsRevision')->willReturn(false);
+        $asset->method('getScenario')->willReturn(Asset::SCENARIO_DEFAULT);
+        $asset->propagating = false;
+        $asset->resaving = false;
+
+        self::assertFalse(ContextCache::shouldSkipInvalidation($asset));
+    }
+
+    public function testDraftShortCircuitsBeforeEntryStatusCheck(): void
+    {
+        // Pins evaluation order: drafts/revisions are checked before the
+        // smart-skip entry-status branch. If the order ever flips,
+        // getDirtyAttributes() would fire on draft saves — a different code
+        // path with different semantics. expects(never) on getDirtyAttributes
+        // is the load-bearing assertion.
+        $entry = $this->createMock(Entry::class);
+        $entry->method('getIsDraft')->willReturn(true);
+        $entry->method('getIsRevision')->willReturn(false);
+        $entry->expects(self::never())->method('getDirtyAttributes');
+
+        self::assertTrue(ContextCache::shouldSkipInvalidation($entry));
+    }
+
+    public function testSkipsNestedEntryWhoseOwnerIsADraft(): void
+    {
+        // ElementHelper::isDraftOrRevision walks up via getOwner() for
+        // NestedElementInterface elements (which Entry implements). A matrix
+        // block whose owner is a draft should skip — even though the block
+        // itself doesn't claim to be a draft.
+        $owner = $this->createMock(Entry::class);
+        $owner->method('getIsDraft')->willReturn(true);
+        $owner->method('getIsRevision')->willReturn(false);
+
+        $block = $this->createMock(Entry::class);
+        $block->method('getIsDraft')->willReturn(false);
+        $block->method('getIsRevision')->willReturn(false);
+        $block->method('getOwner')->willReturn($owner);
+
+        self::assertTrue(ContextCache::shouldSkipInvalidation($block));
     }
 }

--- a/tests/Unit/ContextCacheTest.php
+++ b/tests/Unit/ContextCacheTest.php
@@ -28,4 +28,14 @@ final class ContextCacheTest extends TestCase
 
         self::assertTrue(ContextCache::shouldSkipInvalidation($entry));
     }
+
+    public function testSkipsPropagatingSaves(): void
+    {
+        $entry = $this->createMock(Entry::class);
+        $entry->method('getIsDraft')->willReturn(false);
+        $entry->method('getIsRevision')->willReturn(false);
+        $entry->propagating = true;
+
+        self::assertTrue(ContextCache::shouldSkipInvalidation($entry));
+    }
 }

--- a/tests/Unit/ContextCacheTest.php
+++ b/tests/Unit/ContextCacheTest.php
@@ -38,4 +38,15 @@ final class ContextCacheTest extends TestCase
 
         self::assertTrue(ContextCache::shouldSkipInvalidation($entry));
     }
+
+    public function testSkipsBulkResaves(): void
+    {
+        $entry = $this->createMock(Entry::class);
+        $entry->method('getIsDraft')->willReturn(false);
+        $entry->method('getIsRevision')->willReturn(false);
+        $entry->propagating = false;
+        $entry->resaving = true;
+
+        self::assertTrue(ContextCache::shouldSkipInvalidation($entry));
+    }
 }

--- a/tests/Unit/ContextCacheTest.php
+++ b/tests/Unit/ContextCacheTest.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace madebyraygun\blockloader\tests\Unit;
+
+use craft\elements\Asset;
+use craft\elements\Entry;
+use madebyraygun\blockloader\base\ContextCache;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(ContextCache::class)]
+final class ContextCacheTest extends TestCase
+{
+    public function testSkipsDrafts(): void
+    {
+        $entry = $this->createMock(Entry::class);
+        $entry->method('getIsDraft')->willReturn(true);
+        $entry->method('getIsRevision')->willReturn(false);
+
+        self::assertTrue(ContextCache::shouldSkipInvalidation($entry));
+    }
+
+    public function testSkipsRevisions(): void
+    {
+        $entry = $this->createMock(Entry::class);
+        $entry->method('getIsDraft')->willReturn(false);
+        $entry->method('getIsRevision')->willReturn(true);
+
+        self::assertTrue(ContextCache::shouldSkipInvalidation($entry));
+    }
+}

--- a/tests/Unit/ContextCacheTest.php
+++ b/tests/Unit/ContextCacheTest.php
@@ -61,4 +61,95 @@ final class ContextCacheTest extends TestCase
 
         self::assertTrue(ContextCache::shouldSkipInvalidation($asset));
     }
+
+    public function testSkipsDisabledEntryWhenNoTransition(): void
+    {
+        $entry = $this->createMock(Entry::class);
+        $entry->method('getIsDraft')->willReturn(false);
+        $entry->method('getIsRevision')->willReturn(false);
+        $entry->method('getStatus')->willReturn(Entry::STATUS_DISABLED);
+        $entry->method('getDirtyAttributes')->willReturn(['title']);
+        $entry->propagating = false;
+        $entry->resaving = false;
+
+        self::assertTrue(ContextCache::shouldSkipInvalidation($entry));
+    }
+
+    public function testDoesNotSkipDisabledEntryWhenEnabledIsDirty(): void
+    {
+        $entry = $this->createMock(Entry::class);
+        $entry->method('getIsDraft')->willReturn(false);
+        $entry->method('getIsRevision')->willReturn(false);
+        $entry->method('getStatus')->willReturn(Entry::STATUS_DISABLED);
+        $entry->method('getDirtyAttributes')->willReturn(['enabled']);
+        $entry->propagating = false;
+        $entry->resaving = false;
+
+        self::assertFalse(ContextCache::shouldSkipInvalidation($entry));
+    }
+
+    public function testDoesNotSkipDisabledEntryWhenPostDateIsDirty(): void
+    {
+        $entry = $this->createMock(Entry::class);
+        $entry->method('getIsDraft')->willReturn(false);
+        $entry->method('getIsRevision')->willReturn(false);
+        $entry->method('getStatus')->willReturn(Entry::STATUS_PENDING);
+        $entry->method('getDirtyAttributes')->willReturn(['postDate']);
+        $entry->propagating = false;
+        $entry->resaving = false;
+
+        self::assertFalse(ContextCache::shouldSkipInvalidation($entry));
+    }
+
+    public function testDoesNotSkipDisabledEntryWhenExpiryDateIsDirty(): void
+    {
+        $entry = $this->createMock(Entry::class);
+        $entry->method('getIsDraft')->willReturn(false);
+        $entry->method('getIsRevision')->willReturn(false);
+        $entry->method('getStatus')->willReturn(Entry::STATUS_EXPIRED);
+        $entry->method('getDirtyAttributes')->willReturn(['expiryDate']);
+        $entry->propagating = false;
+        $entry->resaving = false;
+
+        self::assertFalse(ContextCache::shouldSkipInvalidation($entry));
+    }
+
+    public function testSkipsPendingEntryWhenNoTransition(): void
+    {
+        $entry = $this->createMock(Entry::class);
+        $entry->method('getIsDraft')->willReturn(false);
+        $entry->method('getIsRevision')->willReturn(false);
+        $entry->method('getStatus')->willReturn(Entry::STATUS_PENDING);
+        $entry->method('getDirtyAttributes')->willReturn([]);
+        $entry->propagating = false;
+        $entry->resaving = false;
+
+        self::assertTrue(ContextCache::shouldSkipInvalidation($entry));
+    }
+
+    public function testDoesNotSkipLiveEntry(): void
+    {
+        $entry = $this->createMock(Entry::class);
+        $entry->method('getIsDraft')->willReturn(false);
+        $entry->method('getIsRevision')->willReturn(false);
+        $entry->method('getStatus')->willReturn(Entry::STATUS_LIVE);
+        $entry->method('getDirtyAttributes')->willReturn(['title']);
+        $entry->propagating = false;
+        $entry->resaving = false;
+
+        self::assertFalse(ContextCache::shouldSkipInvalidation($entry));
+    }
+
+    public function testDoesNotSkipLiveEntryEvenWithTransitionAttrDirty(): void
+    {
+        $entry = $this->createMock(Entry::class);
+        $entry->method('getIsDraft')->willReturn(false);
+        $entry->method('getIsRevision')->willReturn(false);
+        $entry->method('getStatus')->willReturn(Entry::STATUS_LIVE);
+        $entry->method('getDirtyAttributes')->willReturn(['expiryDate']);
+        $entry->propagating = false;
+        $entry->resaving = false;
+
+        self::assertFalse(ContextCache::shouldSkipInvalidation($entry));
+    }
 }


### PR DESCRIPTION
## Summary

Adds `ContextCache::shouldSkipInvalidation(Element $element): bool` and gates every `EVENT_AFTER_SAVE` listener (immediate + deferred paths, Entry + Asset) on it.

Skipped saves:

- Drafts and revisions (`ElementHelper::isDraftOrRevision`)
- Propagating multi-site saves (`$element->propagating`)
- Bulk resaves (`$element->resaving`)
- Asset indexer passes (`Asset::SCENARIO_INDEX`)
- Non-live entries with no live-ness transition (currently disabled/pending/expired AND none of `enabled` / `postDate` / `expiryDate` is in `getDirtyAttributes()`)

The smart-skip on non-live entries still invalidates when status flips (e.g. `live → disabled`) so descriptors that cached the now-hidden entry's data refresh.

## Smoking gun

Prod incident on `mainstreet.org`, 2026-05-20 ~15:55 UTC: PHP-FPM workers saturated on `save-draft` autosave POSTs to a single news entry. Nginx returned 504s to unrelated anonymous traffic for ~2 minutes as workers stayed pinned in `ContextCache::clearRelations()` → `Entry::find()->relatedTo()->all()`. The 3.1.7 deferred-pass fix took the worst case from "60+ second" to "still bad"; this PR makes the common-case no-op save genuinely free.

## Acceptance criteria (from #27)

- [x] Cache invalidation is skipped entirely for disabled/unpublished entries and drafts
- [x] Published entry saves still correctly invalidate related caches
- [ ] Relation query performance is improved (reduced rows examined) — **deferred to a follow-up PR** (issue #27 part 2)
- [x] All linting checks pass
- [x] Update test coverage — bootstraps PHPUnit and adds 12 unit tests covering each skip rule branch
- [ ] Create or update documentation, making sure to remove any out of date information — no doc surface changed; the existing README description still holds
- [x] **IMPORTANT**: PRs must be DRAFTS until manually reviewed — opened as draft

## Test plan

- [x] `composer test` — 12 unit tests, all passing (1 PHP 8.5 deprecation notice on Craft's `Asset::getWidth()` signature, unrelated to this change)
- [x] `composer check-cs` — clean
- [x] `composer phpstan` — no new errors introduced by this change (30 pre-existing errors on dev unchanged; out of scope)
- [ ] Reviewer: install this branch in a local Craft project with block-loader enabled, autosave on an entry that has many related entries, confirm no relation-query work runs in the deferred pass

## Out of scope

- Issue #27 part 2 (`Entry::find()->relatedTo()` query optimization)
- GitHub Actions CI to run `composer test` automatically
- Behavioral / integration tests requiring a real Craft bootstrap
- Cleanup of the 30 pre-existing PHPStan errors on `dev`